### PR TITLE
Remove string interpolation from mvn-autoenforce

### DIFF
--- a/files/scripts/mvn-autoenforce
+++ b/files/scripts/mvn-autoenforce
@@ -29,7 +29,8 @@ def parse_dependency(dependency_str):
 def find_highest_version(dependency, input):
     highest_version = dependency['version']
     candidate_version_pattern = re.compile(
-        f'{dependency["group_id"]}:{dependency["artifact_id"]}:(\\S+)')
+        '{group_id}:{artifact_id}:(\\S+)'.format(group_id=dependency["group_id"],
+                                                 artifact_id=dependency["artifact_id"]))
     for candidate_version_str in re.findall(candidate_version_pattern, input):
         candidate_version = parse_version(candidate_version_str)
         highest_version = max(highest_version, candidate_version)
@@ -41,13 +42,15 @@ def format_version(version):
 
 
 def to_xml(dependency):
-    return f'''
+    return '''
 <dependency>
-  <groupId>{dependency['group_id']}</groupId>
-  <artifactId>{dependency['artifact_id']}</artifactId>
-  <version>{format_version(dependency['version'])}</version>
+  <groupId>{group_id}</groupId>
+  <artifactId>{artifact_id}</artifactId>
+  <version>{version}</version>
 </dependency>
-    '''.strip()
+    '''.format(group_id=dependency["group_id"],
+               artifact_id=dependency["artifact_id"],
+               version=format_version(dependency['version'])).strip()
 
 
 def main():


### PR DESCRIPTION
The standard python-3 on ubuntu does not yet support string interpolation. Replace it with string formatting.

@odsod 